### PR TITLE
Make DPI aware

### DIFF
--- a/src/stub/xulrunner-stub.exe.manifest
+++ b/src/stub/xulrunner-stub.exe.manifest
@@ -26,6 +26,12 @@
     </ms_asmv3:requestedPrivileges>
   </ms_asmv3:security>
 </ms_asmv3:trustInfo>
+  <ms_asmv3:application xmlns:ms_asmv3="urn:schemas-microsoft-com:asm.v3">
+    <ms_asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+      <dpiAware>True/PM</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
+    </ms_asmv3:windowsSettings>
+  </ms_asmv3:application>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>


### PR DESCRIPTION
Adds a manifest XML entry from [firefox](https://dxr.mozilla.org/mozilla-central/source/browser/app/firefox.exe.manifest#29-34) which makes the xulrunner application DPI aware (and not look blurry on non 100% scaling).